### PR TITLE
Fix: Input-slider min value to avoid app collapse

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         </div>
         <span class="range-input-conti" id="range-input-conti">
 
-          <input type="range" class="custom-range" id="slider" min="0" max="12" value="8" step="1">
+          <input type="range" class="custom-range" id="slider" min="4" max="12" value="8" step="1">
         </span>
         <!-- CHeckboxes -->
         <!-- CHeckboxes -->


### PR DESCRIPTION
- fix the issue #11

Instead of 1, I set the min value of the slider to 4. 1, 2 or 3 would be still too short.
